### PR TITLE
Refactor curriculum schema to version 2.0.0

### DIFF
--- a/src/mongosh/config/curriculum.json
+++ b/src/mongosh/config/curriculum.json
@@ -1,7 +1,11 @@
 {
   "name": "curriculum",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "indexes": [
+    {
+      "keys": {"resources": 1},
+      "options": {"unique": false}
+    },
     {
       "keys": {"personId": 1, "roadmapGroup": 1},
       "options": {"unique": false}

--- a/src/mongosh/config/curriculum.json
+++ b/src/mongosh/config/curriculum.json
@@ -3,11 +3,7 @@
   "version": "2.0.0",
   "indexes": [
     {
-      "keys": {"resources": 1},
-      "options": {"unique": false}
-    },
-    {
-      "keys": {"personId": 1, "roadmapGroup": 1},
+      "keys": {"_id": 1, "roadmap": 1},
       "options": {"unique": false}
     }
   ],

--- a/src/mongosh/data/curriculum.json
+++ b/src/mongosh/data/curriculum.json
@@ -1,6 +1,10 @@
 [
     {
-        "adhoc": true,
-        "name": "test"
+        "resources": [
+            {
+                "adhoc": true,
+                "name": "test"
+            }
+        ]
     }
 ]

--- a/src/mongosh/data/curriculum.json
+++ b/src/mongosh/data/curriculum.json
@@ -1,10 +1,106 @@
 [
-    {
-        "resources": [
-            {
-                "adhoc": true,
-                "name": "test"
-            }
+      {
+        "curriculumId": "CURR001",
+        "name": "Introduction to Programming",
+        "description": "Learn the basics of programming",
+        "topics": [
+          {
+            "topicId": "TOPIC001",
+            "resourceId": "RES001",
+            "title": "Introduction to Python",
+            "description": "Learn the fundamentals of Python programming language",
+            "duration": 60
+          },
+          {
+            "topicId": "TOPIC002",
+            "resourceId": "RES002",
+            "title": "Variables and Data Types",
+            "description": "Understand variables and different data types in Python",
+            "duration": 90
+          }
+        ],
+        "assignedTo": [
+          "PERSON001",
+          "PERSON002",
+          "PERSON003"
         ]
-    }
+      },
+      {
+        "curriculumId": "CURR002",
+        "name": "Web Development Basics",
+        "description": "Introduction to web development concepts",
+        "topics": [
+          {
+            "topicId": "TOPIC003",
+            "resourceId": "RES003",
+            "title": "HTML Basics",
+            "description": "Learn the basics of HTML for web development",
+            "duration": 45
+          },
+          {
+            "topicId": "TOPIC004",
+            "resourceId": "RES004",
+            "title": "CSS Styling",
+            "description": "Understand CSS for styling web pages",
+            "duration": 60
+          }
+        ],
+        "assignedTo": [
+          "PERSON004",
+          "PERSON005",
+          "PERSON006"
+        ]
+      },
+      {
+        "curriculumId": "CURR003",
+        "name": "Data Science Fundamentals",
+        "description": "Introduction to data science concepts",
+        "topics": [
+          {
+            "topicId": "TOPIC005",
+            "resourceId": "RES005",
+            "title": "Data Analysis with Pandas",
+            "description": "Learn data analysis using Pandas library in Python",
+            "duration": 75
+          },
+          {
+            "topicId": "TOPIC006",
+            "resourceId": "RES006",
+            "title": "Data Visualization with Matplotlib",
+            "description": "Understand data visualization using Matplotlib library",
+            "duration": 60
+          }
+        ],
+        "assignedTo": [
+          "PERSON007",
+          "PERSON008",
+          "PERSON009"
+        ]
+      },
+      {
+        "curriculumId": "CURR004",
+        "name": "Machine Learning Basics",
+        "description": "Introduction to machine learning algorithms",
+        "topics": [
+          {
+            "topicId": "TOPIC007",
+            "resourceId": "RES007",
+            "title": "Linear Regression",
+            "description": "Learn linear regression algorithm for machine learning",
+            "duration": 90
+          },
+          {
+            "topicId": "TOPIC008",
+            "resourceId": "RES008",
+            "title": "Classification Algorithms",
+            "description": "Understand various classification algorithms",
+            "duration": 120
+          }
+        ],
+        "assignedTo": [
+          "PERSON010",
+          "PERSON011",
+          "PERSON012"
+        ]
+      }
 ]

--- a/src/mongosh/schemas/curriculum-2.0.0.json
+++ b/src/mongosh/schemas/curriculum-2.0.0.json
@@ -3,7 +3,6 @@
 	"bsonType": "object",
 	"required": [
 		"_id",
-		"personId",
 		"resources"
 	],
 	"properties": {
@@ -16,16 +15,17 @@
 			"bsonType": "string",
 			"maxLength": 20
 		},
-		"personId": {
-			"description": "The ID of the person this item was assigned to",
-			"bsonType": "objectId"
-		},
 		"resources": {
 			"description": "An array of resources",
 			"bsonType": "array",
 			"items": {
 				"bsonType": "object",
+				"required": ["type", "review", "roadmap"],
 				"properties": {
+					"type": {
+						"description": "Type of the resource (topic or adhoc)",
+						"enum": ["topic", "adhoc"]
+					},
 					"resourceId": {
 						"description": "The ID of the resource assigned",
 						"bsonType": "objectId"
@@ -33,28 +33,44 @@
 					"topicId": {
 						"description": "The ID of the topic associated with the resource",
 						"bsonType": "objectId"
+					},
+					"name": {
+						"description": "The Resource Short Name for adhoc resources",
+						"bsonType": "string",
+						"maxLength": 64
+					},
+					"link": {
+						"description": "The Resource Link for adhoc resources",
+						"bsonType": "string",
+						"maxLength": 64
+					},
+					"review": {
+						"description": "Free text review of the person's experience with this resource",
+						"bsonType": "string",
+						"maxLength": 256
+					},
+					"roadmap": {
+						"description": "The top level grouping Now, Next, Later, Celebrated",
+						"enum": ["completed", "Celebrated", "now", "next", "later"]
 					}
 				},
-				"required": ["resourceId", "topicId"]
+				"oneOf": [
+					{
+						"properties": {
+							"type": { "const": "topic" },
+							"resourceId": { "bsonType": "objectId" },
+							"topicId": { "bsonType": "objectId" }
+						}
+					},
+					{
+						"properties": {
+							"type": { "const": "adhoc" },
+							"name": { "bsonType": "string", "maxLength": 64 },
+							"link": { "bsonType": "string", "maxLength": 64 }
+						}
+					}
+				]
 			}
-		},
-		"adhoc": {
-			"description": "This is an adhoc assignment. This document will not have a resourceId and will use a one-off name/link",
-			"bsonType": "bool"
-		},
-		"name": {
-			"description": "The Resource Short Name for adhoc resources",
-			"bsonType": "string",
-			"maxLength": 64
-		},
-		"link": {
-			"description": "The Resource Link for adhoc resources",
-			"bsonType": "string",
-			"maxLength": 64
-		},
-		"roadmapGroup": {
-			"description": "The top level grouping Now, Next, Later, Celebrated",
-			"bsonType": "string"
 		},
 		"status": {
 			"description": "Archived, Assigned, Started, Completed",
@@ -77,11 +93,6 @@
 			"bsonType": "int",
 			"minimum": 0,
 			"maximum": 5
-		},
-		"review": {
-			"description": "Free text review of the person's experience with this resource",
-			"bsonType": "string",
-			"maxLength": 256
 		}
 	},
 	"additionalProperties": false

--- a/src/mongosh/schemas/curriculum-2.0.0.json
+++ b/src/mongosh/schemas/curriculum-2.0.0.json
@@ -1,33 +1,49 @@
 {
-	"description": "A Learning resource or other activity that is on a persons career or learning roadmap",
+	"description": "A Learning resource or other activity that is on a person's career or learning roadmap",
 	"bsonType": "object",
 	"required": [
-		"_id"
+		"_id",
+		"personId",
+		"resources"
 	],
 	"properties": {
 		"_id": {
 			"description": "The unique identifier for a resource used by a person",
 			"bsonType": "objectId"
 		},
-        "version": {
-			"description": "Scehma Version (only on Version document)",
-            "bsonType": "string",
-            "maxLength": 20
-        },
+		"version": {
+			"description": "Schema Version (only on Version document)",
+			"bsonType": "string",
+			"maxLength": 20
+		},
 		"personId": {
-			"description": "The ID of the person this item was asigned to",
+			"description": "The ID of the person this item was assigned to",
 			"bsonType": "objectId"
 		},
-		"resourceId": {
-			"description": "The ID of the resource asigned",
-			"bsonType": "objectId"
+		"resources": {
+			"description": "An array of resources",
+			"bsonType": "array",
+			"items": {
+				"bsonType": "object",
+				"properties": {
+					"resourceId": {
+						"description": "The ID of the resource assigned",
+						"bsonType": "objectId"
+					},
+					"topicId": {
+						"description": "The ID of the topic associated with the resource",
+						"bsonType": "objectId"
+					}
+				},
+				"required": ["resourceId", "topicId"]
+			}
 		},
 		"adhoc": {
 			"description": "This is an adhoc assignment. This document will not have a resourceId and will use a one-off name/link",
 			"bsonType": "bool"
 		},
 		"name": {
-			"description": "The Resource Shrot Name for adhoc resources",
+			"description": "The Resource Short Name for adhoc resources",
 			"bsonType": "string",
 			"maxLength": 64
 		},
@@ -63,7 +79,7 @@
 			"maximum": 5
 		},
 		"review": {
-			"description": "Free text review of the persons experience with this resource",
+			"description": "Free text review of the person's experience with this resource",
 			"bsonType": "string",
 			"maxLength": 256
 		}


### PR DESCRIPTION
- Updated curriculum schema to version 2.0.0, modifying the structure to establish a 1:1 relationship with persons and an array of resources.
- Removed the "personId" property from the curriculum schema.
- Added "resources" array within the curriculum schema to hold resource objects with "resourceId" and "topicId" properties.
- Updated the configuration file to version 2.0.0 and removed the index on "personId" accordingly.
- Updated the test data in curriculum.json to reflect the new schema structure, ensuring each curriculum object contains an array of resources.